### PR TITLE
feat: 설문 결과 화면 선물 저장 및 재추천 기능 구현

### DIFF
--- a/app/src/main/java/com/kosa/selp/MainActivity.kt
+++ b/app/src/main/java/com/kosa/selp/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -49,7 +50,6 @@ import com.kosa.selp.shared.theme.AppColor
 import com.kosa.selp.shared.theme.SelpTheme
 import dagger.hilt.android.AndroidEntryPoint
 import java.net.URLDecoder
-import androidx.navigation.NavType
 import java.util.Date
 
 @AndroidEntryPoint
@@ -73,9 +73,11 @@ class MainActivity : ComponentActivity() {
                                 selectedIndex = BottomBarRoute.indexOf(currentRoute),
                                 onItemSelected = { index ->
                                     val destination = BottomBarRoute.fromIndex(index)
-                                    navController.navigate(destination) {
-                                        popUpTo("home") { inclusive = false }
-                                        launchSingleTop = true
+                                    if (currentRoute != destination) {
+                                        navController.navigate(destination) {
+                                            popUpTo("home") { inclusive = false }
+                                            launchSingleTop = true
+                                        }
                                     }
                                 }
                             )
@@ -90,10 +92,18 @@ class MainActivity : ComponentActivity() {
                             SplashScreen(
                                 viewModel = loginViewModel,
                                 onNavigateToHome = {
-                                    navController.navigate("home") { popUpTo("splash") { inclusive = true } }
+                                    navController.navigate("home") {
+                                        popUpTo("splash") {
+                                            inclusive = true
+                                        }
+                                    }
                                 },
                                 onNavigateToLogin = {
-                                    navController.navigate("login") { popUpTo("splash") { inclusive = true } }
+                                    navController.navigate("login") {
+                                        popUpTo("splash") {
+                                            inclusive = true
+                                        }
+                                    }
                                 }
                             )
                         }
@@ -103,11 +113,21 @@ class MainActivity : ComponentActivity() {
                                 loginViewModel.loginEvent.collect { event ->
                                     when (event) {
                                         is LoginEvent.LoginSuccess -> {
-                                            Toast.makeText(context, "로그인 성공", Toast.LENGTH_SHORT).show()
-                                            navController.navigate("home") { popUpTo("login") { inclusive = true } }
+                                            Toast.makeText(context, "로그인 성공", Toast.LENGTH_SHORT)
+                                                .show()
+                                            navController.navigate("home") {
+                                                popUpTo("login") {
+                                                    inclusive = true
+                                                }
+                                            }
                                         }
+
                                         is LoginEvent.LoginFailure -> {
-                                            Toast.makeText(context, "로그인 실패: ${event.error.message}", Toast.LENGTH_SHORT).show()
+                                            Toast.makeText(
+                                                context,
+                                                "로그인 실패: ${event.error.message}",
+                                                Toast.LENGTH_SHORT
+                                            ).show()
                                         }
                                     }
                                 }
@@ -192,7 +212,10 @@ class MainActivity : ComponentActivity() {
                             })
                         ) { backStackEntry ->
                             val encodedUrl = backStackEntry.arguments?.getString("url")
-                            val url = if (encodedUrl != null) URLDecoder.decode(encodedUrl, "UTF-8") else null
+                            val url = if (encodedUrl != null) URLDecoder.decode(
+                                encodedUrl,
+                                "UTF-8"
+                            ) else null
                             GiftDetailScreen(url = url, navController = navController)
                         }
 
@@ -224,7 +247,9 @@ class MainActivity : ComponentActivity() {
                                         popUpTo(0) // 모든 백스택 제거
                                     }
                                 },
-                                modifier = Modifier.padding(innerPadding).consumeWindowInsets(innerPadding)
+                                modifier = Modifier
+                                    .padding(innerPadding)
+                                    .consumeWindowInsets(innerPadding)
                             )
                         }
                         animatedComposable("giftBundleList") {
@@ -234,9 +259,13 @@ class MainActivity : ComponentActivity() {
                             MyContactsScreen()
                         }
                         animatedComposable("giftBundleDetail/{bundleId}") { backStackEntry ->
-                            val bundleId = backStackEntry.arguments?.getString("bundleId")?.toLongOrNull()
+                            val bundleId =
+                                backStackEntry.arguments?.getString("bundleId")?.toLongOrNull()
                             if (bundleId != null) {
-                                GiftBundleDetailScreen(bundleId = bundleId, navController = navController)
+                                GiftBundleDetailScreen(
+                                    bundleId = bundleId,
+                                    navController = navController
+                                )
                             }
                         }
                     }
@@ -257,7 +286,8 @@ fun SplashScreen(
         when (isLoggedIn) {
             true -> onNavigateToHome()
             false -> onNavigateToLogin()
-            null -> { /* Wait */ }
+            null -> { /* Wait */
+            }
         }
     }
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {

--- a/app/src/main/java/com/kosa/selp/features/gift/data/remote/GiftApiService.kt
+++ b/app/src/main/java/com/kosa/selp/features/gift/data/remote/GiftApiService.kt
@@ -1,6 +1,8 @@
 package com.kosa.selp.features.gift.data.remote
 
 import com.kosa.selp.features.gift.data.request.GiftBundleRecommendRequestDto
+import com.kosa.selp.features.gift.data.request.GiftBundleSaveRequestDto
+import com.kosa.selp.features.gift.data.request.GiftItemReplaceRequestDto
 import com.kosa.selp.features.gift.data.response.GiftBundleDetailResponseDto
 import com.kosa.selp.features.gift.data.response.GiftBundleItemResponseDto
 import com.kosa.selp.features.gift.data.response.GiftBundleRecommendMessageResponseDto
@@ -22,4 +24,10 @@ interface GiftApiService {
 
     @POST("gift-bundle/recommend")
     suspend fun recommendGiftBundle(@Body giftBundleRecommendRequest: GiftBundleRecommendRequestDto): List<GiftBundleItemResponseDto>
+
+    @POST("gift-bundle/recommend-again")
+    suspend fun replaceGiftItem(@Body giftItemReplaceRequest: GiftItemReplaceRequestDto): GiftBundleItemResponseDto
+
+    @POST("gift-bundle")
+    suspend fun saveGiftBundle(@Body giftBundleSaveRequest: GiftBundleSaveRequestDto)
 }

--- a/app/src/main/java/com/kosa/selp/features/gift/data/repositoryImpl/GiftBundleRepositoryImpl.kt
+++ b/app/src/main/java/com/kosa/selp/features/gift/data/repositoryImpl/GiftBundleRepositoryImpl.kt
@@ -2,6 +2,8 @@ package com.kosa.selp.features.gift.data.repositoryImpl
 
 import com.kosa.selp.features.gift.data.remote.GiftApiService
 import com.kosa.selp.features.gift.data.request.GiftBundleRecommendRequestDto
+import com.kosa.selp.features.gift.data.request.GiftBundleSaveRequestDto
+import com.kosa.selp.features.gift.data.request.GiftItemReplaceRequestDto
 import com.kosa.selp.features.gift.data.response.GiftBundleDetailResponseDto
 import com.kosa.selp.features.gift.data.response.GiftBundleItemResponseDto
 import com.kosa.selp.features.gift.data.response.GiftBundleRecommendMessageResponseDto
@@ -27,4 +29,14 @@ class GiftRepositoryImpl @Inject constructor(
     override suspend fun recommendGiftBundle(giftBundleRecommendRequest: GiftBundleRecommendRequestDto): List<GiftBundleItemResponseDto> {
         return api.recommendGiftBundle(giftBundleRecommendRequest)
     }
+
+    override suspend fun replaceGiftItem(giftItemReplaceRequest: GiftItemReplaceRequestDto): GiftBundleItemResponseDto {
+        return api.replaceGiftItem(giftItemReplaceRequest)
+    }
+
+    override suspend fun saveGiftBundle(giftBundleSaveRequest: GiftBundleSaveRequestDto) {
+        api.saveGiftBundle(giftBundleSaveRequest)
+    }
+
+
 }

--- a/app/src/main/java/com/kosa/selp/features/gift/data/request/GiftBundleSaveRequestDto.kt
+++ b/app/src/main/java/com/kosa/selp/features/gift/data/request/GiftBundleSaveRequestDto.kt
@@ -1,0 +1,26 @@
+package com.kosa.selp.features.gift.data.request
+
+import com.google.gson.annotations.SerializedName
+
+data class GiftBundleSaveRequestDto(
+    @SerializedName("giftIds")
+    val giftIds: List<Long>,
+
+    @SerializedName("ageRange")
+    val ageRange: Int,
+
+    @SerializedName("anniversaryType")
+    val anniversaryType: String,
+
+    @SerializedName("categories")
+    val categories: List<String>,
+
+    @SerializedName("relation")
+    val relation: String,
+
+    @SerializedName("gender")
+    val gender: String,
+
+    @SerializedName("detail")
+    val detail: String
+)

--- a/app/src/main/java/com/kosa/selp/features/gift/data/request/GiftItemReplaceRequestDto.kt
+++ b/app/src/main/java/com/kosa/selp/features/gift/data/request/GiftItemReplaceRequestDto.kt
@@ -1,2 +1,29 @@
 package com.kosa.selp.features.gift.data.request
 
+import com.google.gson.annotations.SerializedName
+
+data class GiftItemReplaceRequestDto(
+    @SerializedName("productId")
+    val productId: Long,
+
+    @SerializedName("ageRange")
+    val ageRange: String?,
+
+    @SerializedName("anniversaryType")
+    val anniversaryType: String?,
+
+    @SerializedName("category")
+    val category: String?,
+
+    @SerializedName("relation")
+    val relation: String?,
+
+    @SerializedName("gender")
+    val gender: String?,
+
+    @SerializedName("price")
+    val price: Long,
+
+    @SerializedName("userMessage")
+    val userMessage: String?
+)

--- a/app/src/main/java/com/kosa/selp/features/gift/data/request/GiftItemReplaceRequestDto.kt
+++ b/app/src/main/java/com/kosa/selp/features/gift/data/request/GiftItemReplaceRequestDto.kt
@@ -1,0 +1,2 @@
+package com.kosa.selp.features.gift.data.request
+

--- a/app/src/main/java/com/kosa/selp/features/gift/domain/repository/GiftRepository.kt
+++ b/app/src/main/java/com/kosa/selp/features/gift/domain/repository/GiftRepository.kt
@@ -1,6 +1,8 @@
 package com.kosa.selp.features.gift.domain.repository
 
 import com.kosa.selp.features.gift.data.request.GiftBundleRecommendRequestDto
+import com.kosa.selp.features.gift.data.request.GiftBundleSaveRequestDto
+import com.kosa.selp.features.gift.data.request.GiftItemReplaceRequestDto
 import com.kosa.selp.features.gift.data.response.GiftBundleDetailResponseDto
 import com.kosa.selp.features.gift.data.response.GiftBundleItemResponseDto
 import com.kosa.selp.features.gift.data.response.GiftBundleRecommendMessageResponseDto
@@ -13,4 +15,7 @@ interface GiftRepository {
     ): GiftBundleRecommendMessageResponseDto
 
     suspend fun recommendGiftBundle(giftBundleRecommendRequest: GiftBundleRecommendRequestDto): List<GiftBundleItemResponseDto>
+    suspend fun replaceGiftItem(giftItemReplaceRequest: GiftItemReplaceRequestDto): GiftBundleItemResponseDto
+
+    suspend fun saveGiftBundle(giftBundleSaveRequest: GiftBundleSaveRequestDto)
 }

--- a/app/src/main/java/com/kosa/selp/features/gift/domain/usecase/ReplaceGiftItemUseCase.kt
+++ b/app/src/main/java/com/kosa/selp/features/gift/domain/usecase/ReplaceGiftItemUseCase.kt
@@ -1,2 +1,14 @@
 package com.kosa.selp.features.gift.domain.usecase
 
+import com.kosa.selp.features.gift.data.request.GiftItemReplaceRequestDto
+import com.kosa.selp.features.gift.data.response.GiftBundleItemResponseDto
+import com.kosa.selp.features.gift.domain.repository.GiftRepository
+import javax.inject.Inject
+
+class ReplaceGiftItemUseCase @Inject constructor(
+    private val repository: GiftRepository
+) {
+    suspend operator fun invoke(giftItemReplaceRequest: GiftItemReplaceRequestDto): GiftBundleItemResponseDto {
+        return repository.replaceGiftItem(giftItemReplaceRequest)
+    }
+}

--- a/app/src/main/java/com/kosa/selp/features/gift/domain/usecase/ReplaceGiftItemUseCase.kt
+++ b/app/src/main/java/com/kosa/selp/features/gift/domain/usecase/ReplaceGiftItemUseCase.kt
@@ -1,0 +1,2 @@
+package com.kosa.selp.features.gift.domain.usecase
+

--- a/app/src/main/java/com/kosa/selp/features/gift/domain/usecase/SaveGiftBundleUseCase.kt
+++ b/app/src/main/java/com/kosa/selp/features/gift/domain/usecase/SaveGiftBundleUseCase.kt
@@ -1,0 +1,13 @@
+package com.kosa.selp.features.gift.domain.usecase
+
+import com.kosa.selp.features.gift.data.request.GiftBundleSaveRequestDto
+import com.kosa.selp.features.gift.domain.repository.GiftRepository
+import javax.inject.Inject
+
+class SaveGiftBundleUseCase @Inject constructor(
+    private val repository: GiftRepository
+) {
+    suspend operator fun invoke(giftBundleSaveRequestDto: GiftBundleSaveRequestDto) {
+        return repository.saveGiftBundle(giftBundleSaveRequestDto)
+    }
+}

--- a/app/src/main/java/com/kosa/selp/features/survey/presentation/composable/SurveyResultContent.kt
+++ b/app/src/main/java/com/kosa/selp/features/survey/presentation/composable/SurveyResultContent.kt
@@ -1,16 +1,26 @@
 package com.kosa.selp.features.survey.presentation.composable
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.SpanStyle
@@ -20,15 +30,21 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.kosa.selp.features.gift.data.response.GiftBundleItemResponseDto
+import com.kosa.selp.features.survey.presentation.viewModel.SurveyViewModel
 import com.kosa.selp.shared.composable.gift.GiftCarouselMultiBrowse
 import com.kosa.selp.shared.theme.AppColor
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @Composable
 fun SurveyResultContent(
     gifts: List<GiftBundleItemResponseDto>,
-    navController: NavController
+    navController: NavController,
+    viewModel: SurveyViewModel
 ) {
     val isEmpty = gifts.isEmpty()
+    var isSaving by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
 
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -53,23 +69,71 @@ fun SurveyResultContent(
         )
 
         Spacer(modifier = Modifier.height(24.dp))
-        
+
         if (!isEmpty) {
-            GiftCarouselMultiBrowse(gifts)
+            GiftCarouselMultiBrowse(
+                gifts = gifts,
+                onReplaceClick = { gift ->
+                    viewModel.replaceGiftItem(gift)
+                },
+                loadingItemIds = viewModel.loadingItemIds.collectAsState().value
+            )
             Spacer(modifier = Modifier.weight(1f))
             Button(
-                onClick = { navController.navigate("home") },
+                onClick = {
+                    if (!isSaving) {
+                        isSaving = true
+                        viewModel.saveGiftBundle(
+                            onSuccess = {
+                                coroutineScope.launch {
+                                    delay(300)
+                                    isSaving = false
+                                    navController.navigate("home")
+                                }
+                            },
+                            onFailure = { error ->
+                                coroutineScope.launch {
+                                    delay(200)
+                                    isSaving = false
+                                    println("저장 실패: ${error.message}")
+                                }
+                            }
+                        )
+                    }
+                },
+                enabled = !isSaving,
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(48.dp),
                 shape = RoundedCornerShape(12.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = AppColor.primary)
-            ) {
-                Text(
-                    "이렇게 결정!",
-                    color = AppColor.white,
-                    style = MaterialTheme.typography.labelLarge
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = if (isSaving) AppColor.primary.copy(alpha = 0.7f) else AppColor.primary,
+                    disabledContainerColor = AppColor.primary.copy(alpha = 0.7f)
                 )
+            ) {
+                if (isSaving) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            color = AppColor.white,
+                            strokeWidth = 2.dp
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            "저장 중...",
+                            color = AppColor.white,
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                    }
+                } else {
+                    Text(
+                        "이렇게 결정!",
+                        color = AppColor.white,
+                        style = MaterialTheme.typography.labelLarge
+                    )
+                }
             }
         } else {
             Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/com/kosa/selp/shared/composable/gift/GiftCarouselMultiBrowse.kt
+++ b/app/src/main/java/com/kosa/selp/shared/composable/gift/GiftCarouselMultiBrowse.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -36,7 +37,12 @@ import java.text.DecimalFormat
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun GiftCarouselMultiBrowse(gifts: List<GiftBundleItemResponseDto>) {
+fun GiftCarouselMultiBrowse(
+    gifts: List<GiftBundleItemResponseDto>,
+    onReplaceClick: (GiftBundleItemResponseDto) -> Unit,
+    loadingItemIds: Set<Long> = emptySet()
+
+) {
     val windowSize = LocalWindowInfo.current.containerSize
     val screenWidth = with(LocalDensity.current) { windowSize.width.toDp() }
     val screenHeight = with(LocalDensity.current) { windowSize.height.toDp() }
@@ -64,63 +70,81 @@ fun GiftCarouselMultiBrowse(gifts: List<GiftBundleItemResponseDto>) {
         contentPadding = PaddingValues(horizontal = horizontalPadding)
     ) { index ->
         val gift = gifts[index]
+        val isLoading = gift.id in loadingItemIds
 
         Box(
             modifier = Modifier
                 .height(cardHeight)
                 .maskClip(MaterialTheme.shapes.extraLarge)
         ) {
-            Image(
-                painter = rememberAsyncImagePainter(gift.imagePath),
-                contentDescription = gift.name,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize()
-            )
-
-            AssistChip(
-                onClick = {},
-                label = {
-                    Text(
-                        "재추천",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = AppColor.white
-                    )
-                },
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(12.dp),
-                shape = RoundedCornerShape(50),
-                border = BorderStroke(1.dp, AppColor.primary),
-                colors = AssistChipDefaults.assistChipColors(
-                    containerColor = AppColor.primary,
-                    labelColor = Color.White
+            if (isLoading) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(AppColor.surface),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(color = AppColor.primary)
+                }
+            } else {
+                Image(
+                    painter = rememberAsyncImagePainter(gift.imagePath),
+                    contentDescription = gift.name,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
                 )
-            )
 
-            Column(
-                modifier = Modifier
-                    .align(Alignment.BottomStart)
-                    .fillMaxWidth()
-                    .background(
-                        Brush.verticalGradient(
-                            listOf(Color.Transparent, Color(0xCC000000))
+                AssistChip(
+                    onClick = { onReplaceClick(gift) },
+                    label = {
+                        Text(
+                            "재추천",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = AppColor.white
+                        )
+                    },
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(12.dp),
+                    shape = RoundedCornerShape(50),
+                    border = BorderStroke(1.dp, AppColor.primary),
+                    colors = AssistChipDefaults.assistChipColors(
+                        containerColor = AppColor.primary,
+                        labelColor = Color.White
+                    )
+                )
+
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .fillMaxWidth()
+                        .background(
+                            Brush.verticalGradient(
+                                listOf(Color.Transparent, Color(0xCC000000))
+                            )
+                        )
+                        .padding(12.dp)
+                ) {
+                    Text(
+                        text = gift.name,
+                        style = MaterialTheme.typography.bodyLarge.copy(
+                            color = Color.White,
+                            fontWeight = FontWeight.SemiBold
+                        ),
+                        maxLines = 1
+                    )
+                    Text(
+                        text = "${DecimalFormat("#,###").format(gift.price)}원",
+                        style = MaterialTheme.typography.bodyMedium.copy(
+                            color = Color.White.copy(
+                                alpha = 0.85f
+                            )
                         )
                     )
-                    .padding(12.dp)
-            ) {
-                Text(
-                    text = gift.name,
-                    style = MaterialTheme.typography.bodyLarge.copy(
-                        color = Color.White,
-                        fontWeight = FontWeight.SemiBold
-                    ),
-                    maxLines = 1
-                )
-                Text(
-                    text = "${DecimalFormat("#,###").format(gift.price)}원",
-                    style = MaterialTheme.typography.bodyMedium.copy(color = Color.White.copy(alpha = 0.85f))
-                )
+                }
             }
+
+
         }
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

- 설문 추천 결과 화면에서 선물 꾸러미 저장 및 추천 상품 교체 기능을 추가
- 사용자가 추천 결과에서 "이렇게 결정!" 버튼을 누르면 선물 꾸러미가 저장되며, 이후 홈으로 이동
- 추천 상품 카드에서 "재추천" 버튼을 누르면 해당 상품만 교체되도록 API 연동 및 UI 업데이트를 구현
- 저장 시 UI에서 "저장 중입니다..." 상태 표시를 추가하여 자연스러운 흐름 제공
- 결과 화면에서 Lottie 애니메이션이 로딩 이후 한 번만 실행
- 하단 바에서 현재 선택된 탭을 다시 누를 경우 중복 navigate가 발생하지 않도록 개선



## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항

- Lottie 애니메이션이 간헐적으로 재생되지 않던 문제는 LaunchedEffect 상태 분리
- navigate("home") 동작이 너무 빠르게 전환되어 사용자가 의도를 인식하지 못하던 문제는 딜레이 및 로딩 텍스트 표시로 해결

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
